### PR TITLE
Add Forgejo Actions job and log tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,9 @@ List all my repositories
 | `dispatch_workflow` | Trigger a workflow run via `workflow_dispatch` event |
 | `list_workflow_runs` | List workflow runs with optional filtering by status, event, or SHA |
 | `get_workflow_run` | Get details of a specific workflow run by ID |
+| `list_workflow_run_jobs` | List jobs for a workflow run with per-job status and log hints |
+| `get_workflow_job_logs` | Download plaintext logs for a single workflow job; supports attempt and tailing |
+| `get_workflow_run_logs` | Download a base64 ZIP of plaintext logs for every job in a workflow run |
 | **Organizations** | |
 | `search_org_teams` | Search for teams in an organization |
 | **Time Tracking** | |

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -262,6 +262,14 @@
       "description": "Get details of a specific workflow run"
     },
     {
+      "name": "get_workflow_job_logs",
+      "description": "Download plaintext logs for a single workflow job"
+    },
+    {
+      "name": "get_workflow_run_logs",
+      "description": "Download a ZIP archive of logs for a workflow run"
+    },
+    {
       "name": "issue_state_change",
       "description": "Change issue state"
     },
@@ -360,6 +368,10 @@
     {
       "name": "list_workflow_runs",
       "description": "List workflow runs for a repository"
+    },
+    {
+      "name": "list_workflow_run_jobs",
+      "description": "List jobs for a workflow run"
     },
     {
       "name": "mark_all_notifications_read",

--- a/operation/actions/actions.go
+++ b/operation/actions/actions.go
@@ -36,6 +36,9 @@ func RegisterTool(s *server.MCPServer) {
 	s.AddTool(DispatchWorkflowTool, DispatchWorkflowFn)
 	s.AddTool(ListWorkflowRunsTool, ListWorkflowRunsFn)
 	s.AddTool(GetWorkflowRunTool, GetWorkflowRunFn)
+	s.AddTool(ListWorkflowRunJobsTool, ListWorkflowRunJobsFn)
+	s.AddTool(GetWorkflowJobLogsTool, GetWorkflowJobLogsFn)
+	s.AddTool(GetWorkflowRunLogsTool, GetWorkflowRunLogsFn)
 }
 
 func DispatchWorkflowFn(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/operation/actions/actions_test.go
+++ b/operation/actions/actions_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"codeberg.org/goern/forgejo-mcp/v2/pkg/flag"
 	"codeberg.org/goern/forgejo-mcp/v2/pkg/forgejo"
 	forgejo_sdk "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -169,6 +170,8 @@ func setupListRunsMockServer(t *testing.T, response interface{}, statusCode int)
 		t.Fatalf("creating test client: %v", err)
 	}
 	forgejo.SetClientForTesting(client)
+	flag.URL = srv.URL
+	t.Cleanup(func() { flag.URL = "" })
 
 	return srv, &capturedPath
 }
@@ -312,5 +315,91 @@ func TestGetWorkflowRunFn_MissingRunID(t *testing.T) {
 	_, err := GetWorkflowRunFn(context.Background(), req)
 	if err == nil {
 		t.Fatal("expected error for missing run_id, got nil")
+	}
+}
+
+func TestListWorkflowRunJobsFn_ReturnsJobs(t *testing.T) {
+	mockResponse := []map[string]interface{}{
+		{
+			"id":      101,
+			"run_id":  42,
+			"attempt": 2,
+			"name":    "build",
+			"status":  "success",
+			"task_id": 555,
+			"runs_on": []string{"ubuntu-latest"},
+		},
+	}
+
+	srv, capturedPath := setupListRunsMockServer(t, mockResponse, http.StatusOK)
+	defer srv.Close()
+
+	req := newCallToolRequest(map[string]interface{}{
+		"owner":  "testowner",
+		"repo":   "testrepo",
+		"run_id": float64(42),
+	})
+
+	result, err := ListWorkflowRunJobsFn(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ListWorkflowRunJobsFn returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("ListWorkflowRunJobsFn returned tool error")
+	}
+
+	expectedPath := "/api/v1/repos/testowner/testrepo/actions/runs/42/jobs"
+	if *capturedPath != expectedPath {
+		t.Errorf("wrong path: got %q, want %q", *capturedPath, expectedPath)
+	}
+}
+
+func TestGetWorkflowJobLogsFn_ReturnsTail(t *testing.T) {
+	srv, capturedPath := setupListRunsMockServer(t, "line1\nline2\nline3\n", http.StatusOK)
+	defer srv.Close()
+
+	req := newCallToolRequest(map[string]interface{}{
+		"owner":      "testowner",
+		"repo":       "testrepo",
+		"job_id":     float64(101),
+		"attempt":    float64(2),
+		"tail_lines": float64(2),
+	})
+
+	result, err := GetWorkflowJobLogsFn(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetWorkflowJobLogsFn returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("GetWorkflowJobLogsFn returned tool error")
+	}
+
+	expectedPath := "/api/v1/repos/testowner/testrepo/actions/jobs/101/logs"
+	if *capturedPath != expectedPath {
+		t.Errorf("wrong path: got %q, want %q", *capturedPath, expectedPath)
+	}
+}
+
+func TestGetWorkflowRunLogsFn_ReturnsZipMetadata(t *testing.T) {
+	srv, capturedPath := setupListRunsMockServer(t, "PK\x03\x04", http.StatusOK)
+	defer srv.Close()
+
+	req := newCallToolRequest(map[string]interface{}{
+		"owner":  "testowner",
+		"repo":   "testrepo",
+		"run_id": float64(42),
+	})
+
+	result, err := GetWorkflowRunLogsFn(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetWorkflowRunLogsFn returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("GetWorkflowRunLogsFn returned tool error")
+	}
+
+	expectedPath := "/api/v1/repos/testowner/testrepo/actions/runs/42/logs"
+	if *capturedPath != expectedPath {
+		t.Errorf("wrong path: got %q, want %q", *capturedPath, expectedPath)
 	}
 }

--- a/operation/actions/workflow_runs.go
+++ b/operation/actions/workflow_runs.go
@@ -2,8 +2,10 @@ package actions
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"codeberg.org/goern/forgejo-mcp/v2/operation/params"
@@ -16,9 +18,34 @@ import (
 )
 
 const (
-	ListWorkflowRunsToolName = "list_workflow_runs"
-	GetWorkflowRunToolName   = "get_workflow_run"
+	ListWorkflowRunsToolName    = "list_workflow_runs"
+	GetWorkflowRunToolName      = "get_workflow_run"
+	ListWorkflowRunJobsToolName = "list_workflow_run_jobs"
+	GetWorkflowJobLogsToolName  = "get_workflow_job_logs"
+	GetWorkflowRunLogsToolName  = "get_workflow_run_logs"
 )
+
+type actionRunJob struct {
+	ID      int64    `json:"id"`
+	RunID   int64    `json:"run_id"`
+	Attempt int64    `json:"attempt"`
+	Handle  string   `json:"handle"`
+	Name    string   `json:"name"`
+	Status  string   `json:"status"`
+	TaskID  int64    `json:"task_id"`
+	OwnerID int64    `json:"owner_id"`
+	RepoID  int64    `json:"repo_id"`
+	RunsOn  []string `json:"runs_on"`
+	Needs   []string `json:"needs"`
+}
+
+type workflowRunLogsResult struct {
+	Filename      string `json:"filename"`
+	ContentType   string `json:"content_type"`
+	Encoding      string `json:"encoding"`
+	ContentBase64 string `json:"content_base64"`
+	Bytes         int    `json:"bytes"`
+}
 
 var (
 	ListWorkflowRunsTool = mcp.NewTool(
@@ -37,6 +64,32 @@ var (
 	GetWorkflowRunTool = mcp.NewTool(
 		GetWorkflowRunToolName,
 		mcp.WithDescription("Get details of a specific workflow run"),
+		mcp.WithString("owner", mcp.Required(), mcp.Description(params.Owner)),
+		mcp.WithString("repo", mcp.Required(), mcp.Description(params.Repo)),
+		mcp.WithNumber("run_id", mcp.Required(), mcp.Description(params.RunID)),
+	)
+
+	ListWorkflowRunJobsTool = mcp.NewTool(
+		ListWorkflowRunJobsToolName,
+		mcp.WithDescription("List jobs for a workflow run, including per-job status, attempt, task ID, runner labels, and log tool hints."),
+		mcp.WithString("owner", mcp.Required(), mcp.Description(params.Owner)),
+		mcp.WithString("repo", mcp.Required(), mcp.Description(params.Repo)),
+		mcp.WithNumber("run_id", mcp.Required(), mcp.Description(params.RunID)),
+	)
+
+	GetWorkflowJobLogsTool = mcp.NewTool(
+		GetWorkflowJobLogsToolName,
+		mcp.WithDescription("Download plaintext logs for a single workflow job. Omit attempt for the latest attempt; use tail_lines to return only the end."),
+		mcp.WithString("owner", mcp.Required(), mcp.Description(params.Owner)),
+		mcp.WithString("repo", mcp.Required(), mcp.Description(params.Repo)),
+		mcp.WithNumber("job_id", mcp.Required(), mcp.Description(params.JobID)),
+		mcp.WithNumber("attempt", mcp.Description(params.Attempt)),
+		mcp.WithNumber("tail_lines", mcp.Description("Return only the last N log lines"), mcp.Min(1)),
+	)
+
+	GetWorkflowRunLogsTool = mcp.NewTool(
+		GetWorkflowRunLogsToolName,
+		mcp.WithDescription("Download a ZIP archive containing plaintext logs for every job in a workflow run. Returns base64 content when under the inline cap."),
 		mcp.WithString("owner", mcp.Required(), mcp.Description(params.Owner)),
 		mcp.WithString("repo", mcp.Required(), mcp.Description(params.Repo)),
 		mcp.WithNumber("run_id", mcp.Required(), mcp.Description(params.RunID)),
@@ -202,4 +255,146 @@ URL: %s`,
 	)
 
 	return to.TextResult(result)
+}
+
+func ListWorkflowRunJobsFn(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	log.Debugf("Called ListWorkflowRunJobsFn")
+
+	owner, ok := req.GetArguments()["owner"].(string)
+	if !ok || owner == "" {
+		return to.ErrorResult(errors.New("owner is required"))
+	}
+	repo, ok := req.GetArguments()["repo"].(string)
+	if !ok || repo == "" {
+		return to.ErrorResult(errors.New("repo is required"))
+	}
+	runIDFloat, err := to.Float64(req.GetArguments()["run_id"])
+	if err != nil {
+		return to.ErrorResult(errors.New("run_id is required"))
+	}
+	runID := int64(runIDFloat)
+	if runID <= 0 {
+		return to.ErrorResult(errors.New("run_id must be a positive integer"))
+	}
+
+	var jobs []*actionRunJob
+	path := fmt.Sprintf("/repos/%s/%s/actions/runs/%d/jobs", url.PathEscape(owner), url.PathEscape(repo), runID)
+	if err := forgejo.DoJSON(ctx, "GET", path, nil, &jobs); err != nil {
+		return to.ErrorResult(fmt.Errorf("failed to list workflow run jobs: %w", err))
+	}
+	if len(jobs) == 0 {
+		return to.TextResult(fmt.Sprintf("No jobs found for workflow run %d in %s/%s", runID, owner, repo))
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Jobs for workflow run %d in %s/%s:\n\n", runID, owner, repo)
+	for _, job := range jobs {
+		fmt.Fprintf(&sb, "#%d - %s\n", job.ID, job.Name)
+		fmt.Fprintf(&sb, "  Status: %s | Attempt: %d | Task ID: %d\n", job.Status, job.Attempt, job.TaskID)
+		if len(job.RunsOn) > 0 {
+			fmt.Fprintf(&sb, "  Runs on: %s\n", strings.Join(job.RunsOn, ", "))
+		}
+		if len(job.Needs) > 0 {
+			fmt.Fprintf(&sb, "  Needs: %s\n", strings.Join(job.Needs, ", "))
+		}
+		fmt.Fprintf(&sb, "  Logs: call %s with job_id=%d", GetWorkflowJobLogsToolName, job.ID)
+		if job.Attempt > 0 {
+			fmt.Fprintf(&sb, " (attempt=%d for this attempt)", job.Attempt)
+		}
+		fmt.Fprint(&sb, "\n\n")
+	}
+
+	return to.TextResult(sb.String())
+}
+
+func GetWorkflowJobLogsFn(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	log.Debugf("Called GetWorkflowJobLogsFn")
+
+	owner, ok := req.GetArguments()["owner"].(string)
+	if !ok || owner == "" {
+		return to.ErrorResult(errors.New("owner is required"))
+	}
+	repo, ok := req.GetArguments()["repo"].(string)
+	if !ok || repo == "" {
+		return to.ErrorResult(errors.New("repo is required"))
+	}
+	jobIDFloat, err := to.Float64(req.GetArguments()["job_id"])
+	if err != nil {
+		return to.ErrorResult(errors.New("job_id is required"))
+	}
+	jobID := int64(jobIDFloat)
+	if jobID <= 0 {
+		return to.ErrorResult(errors.New("job_id must be a positive integer"))
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/actions/jobs/%d/logs", url.PathEscape(owner), url.PathEscape(repo), jobID)
+	if attemptFloat, err := to.Float64(req.GetArguments()["attempt"]); err == nil {
+		attempt := int64(attemptFloat)
+		if attempt <= 0 {
+			return to.ErrorResult(errors.New("attempt must be a positive integer"))
+		}
+		path += fmt.Sprintf("?attempt=%d", attempt)
+	}
+
+	body, _, err := forgejo.DoAPIRaw(ctx, path)
+	if err != nil {
+		return to.ErrorResult(fmt.Errorf("failed to get workflow job logs: %w", err))
+	}
+	text := string(body)
+	if tailFloat, err := to.Float64(req.GetArguments()["tail_lines"]); err == nil {
+		tailLines := int(tailFloat)
+		if tailLines <= 0 {
+			return to.ErrorResult(errors.New("tail_lines must be a positive integer"))
+		}
+		text = tail(text, tailLines)
+	}
+
+	return to.TextResult(text)
+}
+
+func GetWorkflowRunLogsFn(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	log.Debugf("Called GetWorkflowRunLogsFn")
+
+	owner, ok := req.GetArguments()["owner"].(string)
+	if !ok || owner == "" {
+		return to.ErrorResult(errors.New("owner is required"))
+	}
+	repo, ok := req.GetArguments()["repo"].(string)
+	if !ok || repo == "" {
+		return to.ErrorResult(errors.New("repo is required"))
+	}
+	runIDFloat, err := to.Float64(req.GetArguments()["run_id"])
+	if err != nil {
+		return to.ErrorResult(errors.New("run_id is required"))
+	}
+	runID := int64(runIDFloat)
+	if runID <= 0 {
+		return to.ErrorResult(errors.New("run_id must be a positive integer"))
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s/actions/runs/%d/logs", url.PathEscape(owner), url.PathEscape(repo), runID)
+	body, contentType, err := forgejo.DoAPIRaw(ctx, path)
+	if err != nil {
+		return to.ErrorResult(fmt.Errorf("failed to get workflow run logs: %w", err))
+	}
+	result := workflowRunLogsResult{
+		Filename:      fmt.Sprintf("run-%d-logs.zip", runID),
+		ContentType:   contentType,
+		Encoding:      "base64",
+		ContentBase64: base64.StdEncoding.EncodeToString(body),
+		Bytes:         len(body),
+	}
+
+	return to.SafeTextResult(result)
+}
+
+func tail(text string, lines int) string {
+	parts := strings.SplitAfter(text, "\n")
+	if len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	if lines >= len(parts) {
+		return text
+	}
+	return strings.Join(parts[len(parts)-lines:], "")
 }

--- a/operation/params/params.go
+++ b/operation/params/params.go
@@ -72,6 +72,8 @@ const (
 	RunNumber = "Filter by run number"
 	HeadSHA   = "Filter by HEAD SHA"
 	RunID     = "Run ID"
+	JobID     = "Workflow job ID"
+	Attempt   = "Workflow job attempt number"
 	Status    = "Filter by status (e.g. waiting, running, success, failure, cancelled)"
 
 	// Misc parameters

--- a/pkg/forgejo/rawhttp.go
+++ b/pkg/forgejo/rawhttp.go
@@ -304,6 +304,44 @@ func DoRaw(ctx context.Context, pathOrURL string) ([]byte, string, error) {
 	return buf, ct, nil
 }
 
+// DoAPIRaw fetches raw bytes from a Forgejo REST API path, adding the
+// configured auth header. It is intended for non-JSON API endpoints such as
+// Actions log downloads. The response body is capped at MaxInlineDownloadBytes;
+// ErrPayloadTooLarge is returned if the body would exceed the cap.
+func DoAPIRaw(ctx context.Context, pathOrURL string) ([]byte, string, error) {
+	full, err := resolveURL(pathOrURL)
+	if err != nil {
+		return nil, "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, full, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("build request: %w", err)
+	}
+	setCommonHeaders(ctx, req)
+	req.Header.Set("Accept", "*/*")
+
+	resp, err := doRequest(ctx, req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", httpErrorFromResponse(req, resp)
+	}
+
+	limited := io.LimitReader(resp.Body, MaxInlineDownloadBytes+1)
+	buf, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, "", fmt.Errorf("read body: %w", err)
+	}
+	if int64(len(buf)) > MaxInlineDownloadBytes {
+		return nil, "", ErrPayloadTooLarge
+	}
+	ct := resp.Header.Get("Content-Type")
+	return buf, ct, nil
+}
+
 // helper used by tests to validate URL construction directly.
 func init() {
 	// Validate at init that net/url accepts our base format if set.


### PR DESCRIPTION
## Summary
- add a workflow-run jobs tool with per-job status, attempts, task IDs, and log hints
- add job log and run log download tools for Forgejo Actions
- document the new tools and include them in the extension manifest

## Verification
- go test ./...
- go build ./...
- git diff --check
- FORGEJO_URL=http://example.invalid FORGEJO_TOKEN=*** go run . --cli list | grep -E 'list_workflow_run_jobs|get_workflow_job_logs|get_workflow_run_logs'